### PR TITLE
Handle missing endpoint instead of returning 500.

### DIFF
--- a/lib/champion_core.rb
+++ b/lib/champion_core.rb
@@ -148,7 +148,7 @@ module Champion
       warn "\n\n\n\nQuery against #{fdp_url}  is \n#{query}\n\n\n\n"
       solutions = client.query(query)
       warn solutions.inspect
-      solutions.first[:endpoint].value # can be onlhy one
+      solutions.first&.[](:endpoint)&.value # can be only one
     end
 
     #  THIS IS CALLED BY ALGORITHM!
@@ -211,6 +211,16 @@ module Champion
     #   result = core.run_test(testapi: 'https://tests.ostrails.eu/tests/test1/api', guid: 'https://example.org/target/456')
     #   puts result
     def run_test(testapi:, guid:, testid:)
+      if testapi.to_s.strip.empty?
+        return {
+          '@type' => 'ftr:TestResult',
+          '@id' => "urn:fairchampion:missing-endpoint:#{SecureRandom.uuid}",
+          'value' => 'indeterminate',
+          'log' => "No dcat:endpointURL was found for test #{testid}",
+          'outputFromTest' => { '@id' => testid }
+        }
+      end
+
       testurl = testapi
       begin
         result = RestClient::Request.execute(

--- a/spec/champion__core_spec.rb
+++ b/spec/champion__core_spec.rb
@@ -18,6 +18,15 @@ RSpec.describe Champion::Core do
       endpoint = core.get_test_endpoint_for_testid(testid: 'https://tests.ostrails.eu/tests/fc_metadata_includes_license')
       expect(endpoint).to eq('https://tests.ostrails.eu/assess/test/fc_metadata_includes_license')
     end
+
+    it 'returns nil when the FDP index has no endpoint for the test' do
+      sparql_client = instance_double(SPARQL::Client, query: [])
+      allow(SPARQL::Client).to receive(:new).and_return(sparql_client)
+
+      endpoint = core.get_test_endpoint_for_testid(testid: 'https://tests.example/missing')
+
+      expect(endpoint).to be_nil
+    end
   end
 
   describe '#run_test' do
@@ -31,6 +40,20 @@ RSpec.describe Champion::Core do
         testid: 'https://tests.ostrails.eu/tests/fc_metadata_includes_license'
       )
       expect(result).to eq('result' => 'pass')
+    end
+
+    it 'returns an indeterminate test result when the endpoint is missing' do
+      testid = 'https://tests.example/missing'
+
+      result = core.run_test(testapi: nil, guid: subject, testid: testid)
+
+      expect(result).to include(
+        '@type' => 'ftr:TestResult',
+        'value' => 'indeterminate',
+        'log' => "No dcat:endpointURL was found for test #{testid}",
+        'outputFromTest' => { '@id' => testid }
+      )
+      expect(result['@id']).to start_with('urn:fairchampion:missing-endpoint:')
     end
   end
 end


### PR DESCRIPTION
We had a problem with test_FM_F3_M_MetaIdent not having an endpoint specified, which caused the entire test run to crash and return 500 to the user.
This change should catch such issues and return indeterminate. 